### PR TITLE
Added suppression

### DIFF
--- a/src/main/java/org/datanucleus/jdo/query/JDOQueryProcessor.java
+++ b/src/main/java/org/datanucleus/jdo/query/JDOQueryProcessor.java
@@ -561,6 +561,7 @@ public class JDOQueryProcessor extends AbstractProcessor
     protected void addConstructorWithType(Writer w, String indent, String qclassNameSimple, List<? extends Element> members, String classNameFull, Map<String, TypeMirror> genericLookups)
     throws IOException
     {
+        w.append(indent).append("@SuppressWarnings(\"unchecked\")\n");
         w.append(indent).append("public " + qclassNameSimple).append("(").append(Class.class.getSimpleName() + " type, String name, ExpressionType exprType)\n");
         w.append(indent).append("{\n");
         w.append(indent).append(CODE_INDENT).append("super(type, name, exprType);\n");


### PR DESCRIPTION
When compiling a project that specifies `-Werror`, the auto generated Q classes will prevent the project from compiling. Therefore, I added a suppression on the problem method with the idea that autogenerated classes should not prevent my projects from compiling, but my own code which contains warnings, should.

Here's an example of compiler configuration I typically use in all my projects:

```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-compiler-plugin</artifactId>
    <version>${maven.compiler.plugin.version}</version>
    <configuration>
        <source>${maven.compiler.source}</source>
        <target>${maven.compiler.target}</target>
        <compilerArgs>
            <arg>-Xlint:all</arg>
            <arg>-Xlint:-processing</arg>
            <arg>-Xlint:-serial</arg>
            <arg>-Werror</arg>
        </compilerArgs>
    </configuration>
</plugin>
```